### PR TITLE
Accept recent versions of Cairo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - python
     - pip
     - cffi >=1.1.0
-    - cairo 1.14.*
+    - cairo >=1.14.0
   run:
     - python
     - cffi >=1.1.0
-    - cairo 1.14.*
+    - cairo >=1.14.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: "{{ version }}"
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 15386c3a9e08823d6826c4491eaccc7b7254b1dc587a3b9ce60c350c3f990337
   patches:
@@ -14,19 +13,19 @@ source:
 
 build:
   noarch: python
-  number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 2
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   build:
     - python
     - pip
-    - cffi >=1.1.0
-    - cairo >=1.14.0
+    - cffi >=1.1
+    - cairo >=1.14
   run:
     - python
-    - cffi >=1.1.0
-    - cairo >=1.14.0
+    - cffi >=1.1
+    - cairo >=1.14
 
 test:
   imports:


### PR DESCRIPTION
According to @liZe cairocffi also support more recent versions. As is, it gives me UnsatisfiableError for one environment. See https://github.com/Kozea/cairocffi/issues/138

NOTE! I am not sure if I changed the version number correctly. Should it be ">=1.14.*"?
I am not sure how to update the build number.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
